### PR TITLE
Faster decoder implemented using bufio.Scanner

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -18,22 +18,6 @@ type (
 	}
 )
 
-// NewDecoder builds an SSE decoder with a growing buffer.
-// Lines are limited to bufio.MaxScanTokenSize - 1.
-func NewDecoder(in io.Reader) Decoder {
-	return NewDecoderSize(in, 0)
-}
-
-// NewDecoderSize builds an SSE decoder with the specified buffer size (not growing).
-func NewDecoderSize(in io.Reader, bufferSize int) Decoder {
-	d := &decoder{bufio.NewScanner(in), new(bytes.Buffer)}
-	if bufferSize > 0 {
-		d.scanner.Buffer(make([]byte, bufferSize), bufferSize)
-	}
-	d.scanner.Split(scanLinesCR) // See scanlines.go
-	return d
-}
-
 // Decode reads the input stream and interprets the events in it. Any error while reading is  returned.
 func (d *decoder) Decode() (Event, error) {
 	// Stores event data, which is filled after one or many lines from the reader

--- a/decoder.go
+++ b/decoder.go
@@ -4,17 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-)
-
-const (
-	defaultBufferSize = 8096
-)
-
-const (
-	byteLF    = '\n'
-	byteCR    = '\r'
-	byteSPACE = ' '
-	byteCOLON = ':'
+	"strings"
 )
 
 type (
@@ -23,111 +13,88 @@ type (
 		Decode() (Event, error)
 	}
 	decoder struct {
-		r *bufio.Reader
-
-		// Buffers
-		eventID    *bytes.Buffer
-		eventType  *bytes.Buffer
-		dataBuffer *bytes.Buffer
-		field      *bytes.Buffer
-		value      *bytes.Buffer
+		scanner *bufio.Scanner
+		data    *bytes.Buffer
 	}
 )
 
-// NewDecoder creates a SSE decoder with the default buffer size.
+// NewDecoder builds an SSE decoder with a growing buffer.
+// Lines are limited to bufio.MaxScanTokenSize - 1.
 func NewDecoder(in io.Reader) Decoder {
-	return NewDecoderSize(in, defaultBufferSize)
+	return NewDecoderSize(in, 0)
 }
 
-// NewDecoderSize creates a SSE decoder with the specified buffer size.
-func NewDecoderSize(r io.Reader, bufferSize int) Decoder {
-	d := new(decoder)
-	d.initialise(r, bufferSize)
+// NewDecoderSize builds an SSE decoder with the specified buffer size (not growing).
+func NewDecoderSize(in io.Reader, bufferSize int) Decoder {
+	d := &decoder{bufio.NewScanner(in), new(bytes.Buffer)}
+	if bufferSize > 0 {
+		d.scanner.Buffer(make([]byte, bufferSize), bufferSize)
+	}
+	d.scanner.Split(scanLinesCR) // See scanlines.go
 	return d
-}
-
-func (d *decoder) initialise(r io.Reader, bufferSize int) {
-	normalizer := lineFeedNormalizer{r: r}
-	d.r = bufio.NewReaderSize(&normalizer, bufferSize)
-
-	// Event buffers
-	d.eventID = new(bytes.Buffer)
-	d.eventType = new(bytes.Buffer)
-	d.dataBuffer = new(bytes.Buffer)
-
-	// Parsing buffers
-	d.field = new(bytes.Buffer)
-	d.value = new(bytes.Buffer)
 }
 
 // Decode reads the input stream and interprets the events in it. Any error while reading is  returned.
 func (d *decoder) Decode() (Event, error) {
-	for {
-		line, err := d.r.ReadBytes(byteLF)
-		if err != nil {
-			return nil, err
-		}
+	// Stores event data, which is filled after one or many lines from the reader
+	var id, name string
+	var eventSeen bool
 
+	scanner := d.scanner
+	data := d.data
+	data.Reset()
+	for scanner.Scan() {
+		line := scanner.Text()
 		// Empty line? => Dispatch event
-		// Note the event source spec as defined by w3.org requires skips the event dispatching if
-		// the event name collides with the name of any event as defined in the DOM Events spec.
-		// Decoder does not perform this check, hence it could yield events that would not be valid
-		// in a browser.
-		if len(line) == 1 {
-			// Skip event if Data buffer is empty
-			if d.dataBuffer.Len() == 0 {
-				d.dataBuffer.Reset()
-				d.eventType.Reset()
-				continue
+		if len(line) == 0 {
+			if eventSeen {
+				// Trim the last LF
+				if l := data.Len(); l > 0 {
+					data.Truncate(l - 1)
+				}
+
+				// Note the event source spec as defined by w3.org requires
+				// skips the event dispatching if the event name collides with
+				// the name of any event as defined in the DOM Events spec.
+				// Decoder does not perform this check, hence it could yield
+				// events that would not be valid in a browser.
+				return newEvent(id, name, data.Bytes()), nil
 			}
-
-			data := d.dataBuffer.Bytes()
-
-			// Remove line feed, bounds already checked.
-			data = unsafeTrimSuffixByte(data, byteLF)
-
-			// Create event
-			event := newEvent(d.eventID.String(), d.eventType.String(), data)
-
-			// Clear event buffers
-			d.eventType.Reset()
-			d.dataBuffer.Reset()
-
-			// Dispatch event
-			return event, nil
-		}
-
-		// Remove line feed, bounds already checked.
-		line = unsafeTrimSuffixByte(line, byteLF)
-
-		// Extract field/value for current line
-		d.field.Reset()
-		d.value.Reset()
-
-		colonIndex := bytes.IndexByte(line, byteCOLON)
-		switch colonIndex {
-		case 0:
 			continue
-		case -1:
-			d.field.Write(line)
-		default:
-			d.field.Write(line[:colonIndex])
-			line = line[colonIndex+1:]
-			line = trimPrefixByte(line, byteSPACE)
-			d.value.Write(line)
 		}
 
-		// Process field
-		fieldName := d.field.String()
+		colonIndex := strings.IndexByte(line, ':')
+		if colonIndex == 0 {
+			// Skip comment
+			continue
+		}
+
+		var fieldName, value string
+		if colonIndex == -1 {
+			fieldName = line
+			value = ""
+		} else {
+			// Extract key/value for current line
+			fieldName = line[:colonIndex]
+			if colonIndex < len(line)-1 && line[colonIndex+1] == ' ' {
+				// Trim prefix space
+				value = line[colonIndex+2:]
+			} else {
+				value = line[colonIndex+1:]
+			}
+		}
+
 		switch fieldName {
 		case "event":
-			d.eventType.Write(d.value.Bytes())
+			name = value
+			eventSeen = true
 		case "data":
-			d.dataBuffer.Write(d.value.Bytes())
-			d.dataBuffer.WriteByte(byteLF)
+			data.WriteString(value)
+			data.WriteByte('\n')
+			eventSeen = true
 		case "id":
-			d.eventID.Reset()
-			d.eventID.Write(d.value.Bytes())
+			id = value
+			eventSeen = true
 		case "retry":
 			// TODO(alevinval): unused at the moment, will need refactor
 			// or change on the internal API, as decoder has no knowledge on the underlying connection.
@@ -135,46 +102,10 @@ func (d *decoder) Decode() (Event, error) {
 			// Ignore field
 		}
 	}
-}
 
-type lineFeedNormalizer struct {
-	r    io.Reader
-	last byte
-}
-
-func (lnf *lineFeedNormalizer) Read(p []byte) (int, error) {
-	n, err := lnf.r.Read(p)
-	for i := 0; i < n; i++ {
-		switch p[i] {
-		case byteLF:
-			if lnf.last == byteCR {
-				lnf.last = byteLF
-				copy(p[i:], p[i+1:])
-				n--
-				i--
-			}
-		case byteCR:
-			lnf.last = byteCR
-			p[i] = byteLF
-		default:
-			lnf.last = p[i]
-		}
-	}
-	return n, err
-}
-
-func trimPrefixByte(b []byte, prefix byte) []byte {
-	if len(b) > 0 && b[0] == prefix {
-		return b[1:]
-	}
-	return b
-}
-
-// Trims a suffix without doing a bounds check.
-func unsafeTrimSuffixByte(b []byte, suffix byte) []byte {
-	l := len(b) - 1
-	if b[l] == suffix {
-		return b[:l]
-	}
-	return b
+	// From the specification:
+	// "Once the end of the file is reached, any pending data must be
+	//  discarded. (If the file ends in the middle of an event, before the final
+	//  empty line, the incomplete event is not dispatched.)"
+	return nil, io.EOF
 }

--- a/decoder_go1.5.go
+++ b/decoder_go1.5.go
@@ -1,0 +1,18 @@
+// For go 1.5 and below bufio.Scanner.Buffer() did not exist
+//+build !go1.6
+
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
+
+// NewDecoder builds an SSE decoder with a growing buffer.
+// Lines are limited to bufio.MaxScanTokenSize - 1.
+func NewDecoder(in io.Reader) Decoder {
+	d := &decoder{bufio.NewScanner(in), new(bytes.Buffer)}
+	d.scanner.Split(scanLinesCR) // See scanlines.go
+	return d
+}

--- a/decoder_go1.6.go
+++ b/decoder_go1.6.go
@@ -1,0 +1,28 @@
+// For go 1.5 and below bufio.Scanner.Buffer() did not exist
+//+build go1.6
+
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
+
+// NewDecoder builds an SSE decoder with a growing buffer.
+// Lines are limited to bufio.MaxScanTokenSize - 1.
+func NewDecoder(in io.Reader) Decoder {
+	return NewDecoderSize(in, 0)
+}
+
+// NewDecoderSize builds an SSE decoder with the specified buffer size (not growing).
+//
+// This constructor is only available on go >= 1.6
+func NewDecoderSize(in io.Reader, bufferSize int) Decoder {
+	d := &decoder{bufio.NewScanner(in), new(bytes.Buffer)}
+	if bufferSize > 0 {
+		d.scanner.Buffer(make([]byte, bufferSize), bufferSize)
+	}
+	d.scanner.Split(scanLinesCR) // See scanlines.go
+	return d
+}

--- a/scanlines.go
+++ b/scanlines.go
@@ -1,0 +1,38 @@
+package sse
+
+// scanLinesCRLF is a variation of bufio.ScanLines that also recognizes
+// just CR as EOL (as specified in the EventSource spec)
+func scanLinesCR(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	for i, c := range data {
+		switch c {
+		case '\r':
+			if i == len(data)-1 {
+				if atEOF {
+					return len(data), data[:i], nil
+				}
+				// We have to wait for the next byte to check if it is
+				// a \n
+				return 0, nil, nil
+			} else {
+				j := i
+				i++
+				if data[i] == '\n' {
+					i++
+				}
+				return i, data[:j], nil
+			}
+		case '\n':
+			return i + 1, data[:i], nil
+		}
+	}
+
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}

--- a/scanlines_test.go
+++ b/scanlines_test.go
@@ -1,0 +1,62 @@
+package sse
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestScanLines(t *testing.T) {
+	assert := assert.New(t)
+	for _, test := range []struct {
+		in      string
+		atEOF   bool
+		advance int
+		line    string
+		err     error
+	}{
+		{"", false, 0, "", nil},
+		{"", true, 0, "", nil},
+		{"\n", false, 1, "", nil},
+		{"\n", true, 1, "", nil},
+		{"\na", false, 1, "", nil},
+		{"\na", true, 1, "", nil},
+		{"\r\n", false, 2, "", nil},
+		{"\r\n", true, 2, "", nil},
+		{"\r\na", false, 2, "", nil},
+		{"\r\na", true, 2, "", nil},
+		{"\r", false, 0, "", nil}, // Waiting for \n
+		{"\r", true, 1, "", nil},
+		{"\ra", false, 1, "", nil},
+		{"\ra", true, 1, "", nil},
+		{"\n\r", false, 1, "", nil},
+		{"\n\r", true, 1, "", nil},
+		{"abc", false, 0, "", nil},
+		{"abc", true, 3, "abc", nil},
+		{"abc\n", false, 4, "abc", nil},
+		{"abc\n", true, 4, "abc", nil},
+		{"abc\nx", false, 4, "abc", nil},
+		{"abc\nx", true, 4, "abc", nil},
+		{"abc\n\n", false, 4, "abc", nil},
+		{"abc\n\n", true, 4, "abc", nil},
+		{"abc\r\n", false, 5, "abc", nil},
+		{"abc\r\n", true, 5, "abc", nil},
+		{"abc\r\nx", false, 5, "abc", nil},
+		{"abc\r\nx", true, 5, "abc", nil},
+		{"abc\r", false, 0, "", nil}, // Waiting for \n
+		{"abc\r", true, 4, "abc", nil},
+	} {
+		t.Logf("in: %#v, atEOF: %v", test.in, test.atEOF)
+		advance, line, err := scanLinesCR([]byte(test.in), test.atEOF)
+		if test.err != nil {
+			if assert.Error(err) {
+				assert.Equal(0, advance)
+				assert.Nil(line)
+			}
+		} else {
+			if assert.NoError(err) {
+				assert.Equal(test.advance, advance)
+				assert.Equal(test.line, string(line))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Less code as I reuse [bufio.Scanner](https://golang.org/pkg/bufio/#Scanner) (with a specific separator function to recognize CRLF / CR / LF). Faster and less memory allocations.

Before:

```
BenchmarkDecodeEmptyEvent-4          5000000       369 ns/op     72 B/op       3 allocs/op
BenchmarkDecodeEmptyEventWithIgnoredLine-4   3000000       568 ns/op     90 B/op       5 allocs/op
BenchmarkDecodeShortEvent-4          3000000       441 ns/op    112 B/op       4 allocs/op
BenchmarkDecode1kEvent-4             5000000      2748 ns/op   2113 B/op       4 allocs/op
BenchmarkDecode4kEvent-4              200000      9575 ns/op   8257 B/op       4 allocs/op
BenchmarkDecode8kEvent-4              100000     19882 ns/op  16449 B/op       4 allocs/op
BenchmarkDecode16kEvent-4            3000000     40632 ns/op  41059 B/op       6 allocs/op
```

After:

```
BenchmarkDecodeEmptyEvent-4          5000000       263 ns/op     72 B/op       2 allocs/op
BenchmarkDecodeEmptyEventWithIgnoredLine-4   5000000       363 ns/op     88 B/op       3 allocs/op
BenchmarkDecodeShortEvent-4          5000000       304 ns/op    112 B/op       3 allocs/op
BenchmarkDecode1kEvent-4             1000000      1725 ns/op   2112 B/op       3 allocs/op
BenchmarkDecode4kEvent-4              200000      5720 ns/op   8256 B/op       3 allocs/op
BenchmarkDecode8kEvent-4              200000     11410 ns/op  16448 B/op       3 allocs/op
BenchmarkDecode16kEvent-4            1000000     21835 ns/op  32832 B/op       3 allocs/op
```
