### PR TITLE
eventsource: lastEventID is updated only when the event ID is set.

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -137,7 +137,10 @@ func (es *eventSource) consume() {
 			es.Close()
 			return
 		}
-		es.setLastEventID(ev.ID())
+		id := ev.ID()
+		if id != "" {
+			es.setLastEventID(id)
+		}
 		es.out <- ev
 	}
 }


### PR DESCRIPTION
Fixes #12.
