### PR TITLE
Use (chan struct{}) instead of (chan bool)

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -48,7 +48,7 @@ type (
 		d            Decoder
 		resp         *http.Response
 		out          chan Event
-		closeOutOnce chan bool
+		closeOutOnce chan struct{}
 
 		// Last recorded event ID
 		lastEventID    string
@@ -69,7 +69,7 @@ func NewEventSource(url string) (EventSource, error) {
 		d:            nil,
 		url:          url,
 		out:          make(chan Event),
-		closeOutOnce: make(chan bool),
+		closeOutOnce: make(chan struct{}),
 		retry:        defaultRetry,
 	}
 
@@ -230,7 +230,7 @@ func (es *eventSource) Close() {
 
 func (es *eventSource) sendClose() {
 	select {
-	case es.closeOutOnce <- true:
+	case es.closeOutOnce <- struct{}{}:
 	default:
 	}
 }

--- a/eventsource_test.go
+++ b/eventsource_test.go
@@ -21,7 +21,7 @@ type server struct {
 	Events      chan []byte
 	Hang        bool
 	Reconnects  int
-	closer      chan bool
+	closer      chan struct{}
 }
 
 func newServer() (*httptest.Server, *server) {
@@ -29,7 +29,7 @@ func newServer() (*httptest.Server, *server) {
 		ContentType: eventStream,
 		Reconnects:  1,
 		Events:      make(chan []byte),
-		closer:      make(chan bool),
+		closer:      make(chan struct{}),
 	}
 	return httptest.NewServer(config), config
 }
@@ -69,7 +69,7 @@ func (s *server) Send(data []byte) {
 }
 
 func (s *server) Close() {
-	s.closer <- true
+	s.closer <- struct{}{}
 }
 
 func assertCloses(t *testing.T, es sse.EventSource) bool {
@@ -225,11 +225,11 @@ func TestDropConnectionCanReconnect(t *testing.T) {
 	}
 }
 
-func timeout(d time.Duration) <-chan bool {
-	ch := make(chan bool)
+func timeout(d time.Duration) <-chan struct{} {
+	ch := make(chan struct{})
 	go func() {
 		time.Sleep(d)
-		ch <- true
+		ch <- struct{}{}
 	}()
 	return ch
 }


### PR DESCRIPTION
... when the message content doesn't matter, but only the event.