### PR TITLE
eventsource_test: ensure httptest.Server Close() is called.

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -101,7 +101,7 @@ func (es *eventSource) reconnect() (err error) {
 
 // Attempts to connect and updates internal status depending on the outcome.
 func (es *eventSource) connectOnce() (err error) {
-	es.resp, err = es.httpConnect()
+	es.resp, err = es.doHttpConnect()
 	if err != nil {
 		return
 	}
@@ -111,7 +111,7 @@ func (es *eventSource) connectOnce() (err error) {
 	return
 }
 
-func (es *eventSource) httpConnect() (*http.Response, error) {
+func (es *eventSource) doHttpConnect() (*http.Response, error) {
 	// Prepare request
 	req, err := http.NewRequest("GET", es.url, nil)
 	if err != nil {
@@ -123,11 +123,10 @@ func (es *eventSource) httpConnect() (*http.Response, error) {
 	// Check response
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		es.resp = nil
-		return nil, err
+		return resp, err
 	}
 	if resp.Header.Get("Content-Type") != AllowedContentType {
-		return nil, ErrContentType
+		return resp, ErrContentType
 	}
 	return resp, nil
 }

--- a/eventsource_test.go
+++ b/eventsource_test.go
@@ -16,38 +16,43 @@ const (
 	textPlain   = "text/plain; charset=utf-8"
 )
 
-type server struct {
+type handler struct {
+	// Content Type that will be served by the test server.
 	ContentType string
-	Events      chan []byte
-	Hang        bool
-	Reconnects  int
-	closer      chan struct{}
+
+	// Maximum number of requests that will be served by the handler.
+	// When maximum is reached, the handler will immediately return StatusNoContent
+	// to properly indicate there is nothing left to stream.
+	MaxRequests int
+
+	events chan []byte
+	closer chan struct{}
 }
 
-func newServer() (*httptest.Server, *server) {
-	config := &server{
+func newServer() (*httptest.Server, *handler) {
+	handler := &handler{
 		ContentType: eventStream,
-		Reconnects:  1,
-		Events:      make(chan []byte),
+		MaxRequests: 1,
+		events:      make(chan []byte),
 		closer:      make(chan struct{}),
 	}
-	return httptest.NewServer(config), config
+	return httptest.NewServer(handler), handler
 }
 
-func (s *server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (s *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.Header().Set("Connection", "keep-alive")
 	rw.Header().Set("Content-Type", s.ContentType)
-	if s.Reconnects <= 0 {
+	if s.MaxRequests <= 0 {
 		rw.WriteHeader(http.StatusNoContent)
 		return
 	}
-	s.Reconnects--
+	s.MaxRequests--
 	f, _ := rw.(http.Flusher)
 	f.Flush()
 
 	for {
 		select {
-		case event, ok := <-s.Events:
+		case event, ok := <-s.events:
 			if !ok {
 				return
 			}
@@ -59,46 +64,43 @@ func (s *server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (s *server) SendAndClose(data []byte) {
+func (s *handler) SendAndClose(data []byte) {
 	s.Send(data)
 	s.Close()
 }
 
-func (s *server) Send(data []byte) {
-	s.Events <- data
+func (s *handler) Send(data []byte) {
+	s.events <- data
 }
 
-func (s *server) Close() {
+func (s *handler) Close() {
 	s.closer <- struct{}{}
 }
 
-func assertCloses(t *testing.T, es sse.EventSource) bool {
+// Asserts an sse.EventSource has Closed readyState after calling Close on it.
+func assertCloseClient(t *testing.T, es sse.EventSource) bool {
 	es.Close()
 	maxWaits := 10
 	var waits int
 	for es.ReadyState() == sse.Closing && waits < maxWaits {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(25 * time.Millisecond)
 		waits++
 	}
 	return assert.Equal(t, sse.Closed, es.ReadyState())
 }
 
+// Asserts an sse.EventSource has Open readyState.
 func assertIsOpen(t *testing.T, es sse.EventSource, err error) bool {
 	return assert.Nil(t, err) && assert.Equal(t, sse.Open, es.ReadyState())
 }
 
-func TestNewEventSourceWithInvalidContentType(t *testing.T) {
-	s, config := newServer()
-	config.ContentType = textPlain
-	es, err := sse.NewEventSource(s.URL)
-	if assert.Error(t, err) {
-		assert.Equal(t, sse.ErrContentType, err)
-		assert.Equal(t, s.URL, es.URL())
-		assert.Equal(t, sse.Closed, es.ReadyState())
-		_, ok := <-es.Events()
-		assert.False(t, ok)
-	}
-	assertCloses(t, es)
+func closeTestServer(s *httptest.Server, h *handler) {
+	// The test finished and we are cleaning up: force the handler to return on any
+	// pending request.
+	go h.Close()
+
+	// Shutdown the test server.
+	s.Close()
 }
 
 func TestEventSourceStates(t *testing.T) {
@@ -115,68 +117,92 @@ func TestEventSourceStates(t *testing.T) {
 	}
 }
 
+func TestNewEventSourceWithInvalidContentType(t *testing.T) {
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
+	handler.ContentType = textPlain
+
+	es, err := sse.NewEventSource(s.URL)
+	if assert.Error(t, err) {
+		assert.Equal(t, sse.ErrContentType, err)
+		assert.Equal(t, s.URL, es.URL())
+		assert.Equal(t, sse.Closed, es.ReadyState())
+		_, ok := <-es.Events()
+		assert.False(t, ok)
+	}
+	assertCloseClient(t, es)
+}
+
 func TestNewEventSourceWithRightContentType(t *testing.T) {
-	s, config := newServer()
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
+
 	es, err := sse.NewEventSource(s.URL)
 	if assertIsOpen(t, es, err) {
 		ev := tests.NewEventWithPadding(128)
-		go config.SendAndClose(ev)
+		go handler.SendAndClose(ev)
 		recv, ok := <-es.Events()
 		if assert.True(t, ok) {
 			assert.Equal(t, tests.GetPaddedEventData(ev), recv.Data())
 		}
 	}
-	assertCloses(t, es)
+	assertCloseClient(t, es)
 }
 
 func TestNewEventSourceSendingEvent(t *testing.T) {
-	expectedEvent := tests.NewEventWithPadding(2 << 10)
-	s, config := newServer()
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
+
 	es, err := sse.NewEventSource(s.URL)
 	if assertIsOpen(t, es, err) {
-		go config.SendAndClose(expectedEvent)
+		expectedEvent := tests.NewEventWithPadding(2 << 10)
+		go handler.SendAndClose(expectedEvent)
 		ev, ok := <-es.Events()
 		if assert.True(t, ok) {
 			assert.Equal(t, tests.GetPaddedEventData(expectedEvent), ev.Data())
 		}
 	}
-	assertCloses(t, es)
+	assertCloseClient(t, es)
 }
 
 func TestEventSourceLastEventID(t *testing.T) {
-	ev := tests.NewEventWithPadding(2 << 8)
-	expectedData := tests.GetPaddedEventData(ev)
-	ev = append([]byte("id: 123\n"), ev...)
-	expectedID := "123"
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
 
-	s, config := newServer()
 	es, err := sse.NewEventSource(s.URL)
 	if assertIsOpen(t, es, err) {
-		go config.Send(ev)
+		eventBytes := tests.NewEventWithPadding(2 << 8)
+		expectedData := tests.GetPaddedEventData(eventBytes)
+		eventBytes = append([]byte("id: 123\n"), eventBytes...)
+		expectedID := "123"
+
+		go handler.Send(eventBytes)
 		ev, ok := <-es.Events()
 		if assert.True(t, ok) {
 			assert.Equal(t, expectedID, es.LastEventID())
 			assert.Equal(t, expectedData, ev.Data())
 		}
 
-		go config.Send(tests.NewEventWithPadding(32))
+		go handler.Send(tests.NewEventWithPadding(32))
 		_, ok = <-es.Events()
 		if assert.True(t, ok) {
 			assert.Equal(t, expectedID, es.LastEventID())
 		}
 	}
-	assertCloses(t, es)
+	assertCloseClient(t, es)
 }
 
 func TestEventSourceRetryIsRespected(t *testing.T) {
-	s, config := newServer()
-	config.Reconnects = 3
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
+	handler.MaxRequests = 3
+
 	es, err := sse.NewEventSource(s.URL)
 	if assertIsOpen(t, es, err) {
 		// Big retry
-		config.Send([]byte("retry: 100\n"))
-		config.Close()
-		go config.Send(tests.NewEventWithPadding(128))
+		handler.Send([]byte("retry: 100\n"))
+		handler.Close()
+		go handler.Send(tests.NewEventWithPadding(128))
 		select {
 		case _, ok := <-es.Events():
 			assert.True(t, ok)
@@ -185,9 +211,9 @@ func TestEventSourceRetryIsRespected(t *testing.T) {
 		}
 
 		// Smaller retry
-		config.Send([]byte("retry: 1\n"))
-		config.Close()
-		go config.Send(tests.NewEventWithPadding(128))
+		handler.Send([]byte("retry: 1\n"))
+		handler.Close()
+		go handler.Send(tests.NewEventWithPadding(128))
 		select {
 		case _, ok := <-es.Events():
 			assert.True(t, ok)
@@ -195,34 +221,40 @@ func TestEventSourceRetryIsRespected(t *testing.T) {
 			assert.Fail(t, "event source did not reconnect within the allowed time.")
 		}
 	}
+	assertCloseClient(t, es)
 }
 
 func TestDropConnectionCannotReconnect(t *testing.T) {
-	s, config := newServer()
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
+
 	es, err := sse.NewEventSource(s.URL)
 	if assertIsOpen(t, es, err) {
-		config.Close()
-		go config.Send(tests.NewEventWithPadding(128))
+		handler.Close()
+		go handler.Send(tests.NewEventWithPadding(128))
 		_, ok := <-es.Events()
 		if assert.False(t, ok) {
 			assert.Equal(t, sse.Closed, es.ReadyState())
 		}
 	}
+	assertCloseClient(t, es)
 }
 
 func TestDropConnectionCanReconnect(t *testing.T) {
-	s, config := newServer()
-	config.Reconnects = 2
+	s, handler := newServer()
+	defer closeTestServer(s, handler)
+	handler.MaxRequests = 2
 
 	es, err := sse.NewEventSource(s.URL)
 	if assertIsOpen(t, es, err) {
-		config.Close()
-		go config.Send(tests.NewEventWithPadding(128))
+		handler.Close()
+		go handler.Send(tests.NewEventWithPadding(128))
 		_, ok := <-es.Events()
 		if assert.True(t, ok) {
 			assert.Equal(t, sse.Open, es.ReadyState())
 		}
 	}
+	assertCloseClient(t, es)
 }
 
 func timeout(d time.Duration) <-chan struct{} {


### PR DESCRIPTION
When the client connection is opened, the handler hangs waiting
for events to be sent.

Turns out httptest.Server.Close() respects open connections, for this reason
we now force the handler to return for any pending connection.

Fixes #26.