### PR TITLE
decoder/eventsource: decoder keeps track of LastEventID and Retry.

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -11,7 +11,7 @@ import (
 type (
 	// Decoder interface decodes events from a reader input
 	Decoder interface {
-		Decode() (ev *Event, err error)
+		Decode() (ev *MessageEvent, err error)
 		Retry() (retry int)
 	}
 	decoder struct {
@@ -27,7 +27,7 @@ func (d *decoder) Retry() int {
 }
 
 // Decode reads the input stream and interprets the events in it. Any error while reading is  returned.
-func (d *decoder) Decode() (*Event, error) {
+func (d *decoder) Decode() (*MessageEvent, error) {
 	// Stores event data, which is filled after one or many lines from the reader
 	var name string
 	var eventSeen bool
@@ -49,7 +49,7 @@ func (d *decoder) Decode() (*Event, error) {
 				// the name of any event as defined in the DOM Events spec.
 				// Decoder does not perform this check, hence it could yield
 				// events that would not be valid in a browser.
-				return &Event{d.lastEventID, name, data.String()}, nil
+				return &MessageEvent{d.lastEventID, name, data.String()}, nil
 			}
 			continue
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+// Default retry time in milliseconds.
+// The spec recommends to use a value of a few seconds.
+const defaultRetry = 2500
+
 type (
 	// Decoder interface decodes events from a reader input
 	Decoder interface {

--- a/decoder_go1.5.go
+++ b/decoder_go1.5.go
@@ -12,7 +12,7 @@ import (
 // NewDecoder builds an SSE decoder with a growing buffer.
 // Lines are limited to bufio.MaxScanTokenSize - 1.
 func NewDecoder(in io.Reader) Decoder {
-	d := &decoder{scanner: bufio.NewScanner(in), data: new(bytes.Buffer), retry: 1000}
+	d := &decoder{scanner: bufio.NewScanner(in), data: new(bytes.Buffer), retry: defaultRetry}
 	d.scanner.Split(scanLinesCR) // See scanlines.go
 	return d
 }

--- a/decoder_go1.5.go
+++ b/decoder_go1.5.go
@@ -12,7 +12,7 @@ import (
 // NewDecoder builds an SSE decoder with a growing buffer.
 // Lines are limited to bufio.MaxScanTokenSize - 1.
 func NewDecoder(in io.Reader) Decoder {
-	d := &decoder{bufio.NewScanner(in), new(bytes.Buffer)}
+	d := &decoder{scanner: bufio.NewScanner(in), data: new(bytes.Buffer), retry: 1000}
 	d.scanner.Split(scanLinesCR) // See scanlines.go
 	return d
 }

--- a/decoder_go1.6.go
+++ b/decoder_go1.6.go
@@ -19,7 +19,7 @@ func NewDecoder(in io.Reader) Decoder {
 //
 // This constructor is only available on go >= 1.6
 func NewDecoderSize(in io.Reader, bufferSize int) Decoder {
-	d := &decoder{bufio.NewScanner(in), new(bytes.Buffer)}
+	d := &decoder{scanner: bufio.NewScanner(in), data: new(bytes.Buffer), retry: 1000}
 	if bufferSize > 0 {
 		d.scanner.Buffer(make([]byte, bufferSize), bufferSize)
 	}

--- a/decoder_go1.6.go
+++ b/decoder_go1.6.go
@@ -19,7 +19,7 @@ func NewDecoder(in io.Reader) Decoder {
 //
 // This constructor is only available on go >= 1.6
 func NewDecoderSize(in io.Reader, bufferSize int) Decoder {
-	d := &decoder{scanner: bufio.NewScanner(in), data: new(bytes.Buffer), retry: 1000}
+	d := &decoder{scanner: bufio.NewScanner(in), data: new(bytes.Buffer), retry: defaultRetry}
 	if bufferSize > 0 {
 		d.scanner.Buffer(make([]byte, bufferSize), bufferSize)
 	}

--- a/decoder_retry_test.go
+++ b/decoder_retry_test.go
@@ -10,10 +10,7 @@ import (
 
 func TestDecodeRetry(t *testing.T) {
 	decoder := NewDecoder(bytes.NewReader([]byte("retry: 100\nretry: a\n")))
-	ev, err := decoder.Decode()
-	if assert.NoError(t, err) {
-		assert.Equal(t, 100, ev.retry)
-		_, err = decoder.Decode()
-		assert.Equal(t, io.EOF, err)
-	}
+	_, err := decoder.Decode()
+	assert.Equal(t, 100, decoder.Retry())
+	assert.Equal(t, io.EOF, err)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -66,7 +66,7 @@ func TestStocksExample(t *testing.T) {
 	decoder := newDecoder("data: YHOO\ndata: +2\ndata: 10\n\n")
 	ev, err := decoder.Decode()
 	if assert.NoError(t, err) {
-		assert.Equal(t, "", ev.ID)
+		assert.Equal(t, "", ev.LastEventID)
 		assert.Equal(t, "YHOO\n+2\n10", ev.Data)
 	}
 }
@@ -112,19 +112,19 @@ func TestCommentIsIgnoredAndDataIsNot(t *testing.T) {
 
 	ev1, err := decoder.Decode()
 	if assert.NoError(t, err) {
-		assert.Equal(t, "1", ev1.ID)
+		assert.Equal(t, "1", ev1.LastEventID)
 		assert.Equal(t, "first event", ev1.Data)
 	}
 
 	ev2, err := decoder.Decode()
 	if assert.NoError(t, err) {
-		assert.Equal(t, "", ev2.ID)
+		assert.Equal(t, "", ev2.LastEventID)
 		assert.Equal(t, "second event", ev2.Data)
 	}
 
 	ev3, err := decoder.Decode()
 	if assert.NoError(t, err) {
-		assert.Equal(t, "", ev3.ID)
+		assert.Equal(t, "", ev3.LastEventID)
 		assert.Equal(t, " third event", ev3.Data)
 	}
 }

--- a/event.go
+++ b/event.go
@@ -1,8 +1,7 @@
 package sse
 
 type Event struct {
-	ID    string
-	Name  string
-	Data  string
-	retry int
+	LastEventID string
+	Name        string
+	Data        string
 }

--- a/eventsource.go
+++ b/eventsource.go
@@ -21,8 +21,6 @@ const (
 	Closing
 	// Closed after the connection is closed.
 	Closed
-
-	defaultRetry = 1 * time.Second
 )
 
 var (
@@ -34,7 +32,6 @@ type (
 	EventSource interface {
 		URL() (url string)
 		ReadyState() (state ReadyState)
-		LastEventID() (id string)
 		Events() (events <-chan *Event)
 		Close()
 	}
@@ -45,26 +42,18 @@ type (
 		out          chan *Event
 		closeOutOnce chan struct{}
 
-		// Last recorded event ID
-		lastEventID    string
-		lastEventIDMux sync.RWMutex
-
 		// Status of the event stream.
 		readyState    ReadyState
 		readyStateMux sync.RWMutex
-
-		// Reconnection waiting time
-		retry time.Duration
 	}
 )
 
 // NewEventSource constructs returns an EventSource that satisfies the HTML5 EventSource specification.
 func NewEventSource(url string) (EventSource, error) {
 	es := eventSource{
-		d:     nil,
-		url:   url,
-		out:   make(chan *Event),
-		retry: defaultRetry,
+		d:            nil,
+		url:          url,
+		out:          make(chan *Event),
 	}
 	return &es, es.connect()
 }
@@ -75,7 +64,7 @@ func (es *eventSource) connect() (err error) {
 	es.setReadyState(Connecting)
 	err = es.connectOnce()
 	if err != nil {
-		err = es.reconnect()
+		es.Close()
 	}
 	return
 }
@@ -85,7 +74,7 @@ func (es *eventSource) connect() (err error) {
 func (es *eventSource) reconnect() (err error) {
 	es.setReadyState(Connecting)
 	for es.mustReconnect(err) {
-		time.Sleep(es.retry)
+		time.Sleep(time.Duration(es.d.Retry()) * time.Millisecond)
 		err = es.connectOnce()
 	}
 	if err != nil {
@@ -138,13 +127,6 @@ func (es *eventSource) consume() {
 			es.Close()
 			return
 		}
-		if ev.retry >= 0 {
-			es.retry = time.Duration(ev.retry) * time.Millisecond
-			continue
-		}
-		if ev.ID != "" {
-			es.setLastEventID(ev.ID)
-		}
 		es.out <- ev
 	}
 }
@@ -185,19 +167,6 @@ func (es *eventSource) setReadyState(newState ReadyState) {
 		return
 	}
 	es.readyState = newState
-}
-
-// Returns the last event source Event id.
-func (es *eventSource) LastEventID() string {
-	es.lastEventIDMux.RLock()
-	defer es.lastEventIDMux.RUnlock()
-	return es.lastEventID
-}
-
-func (es *eventSource) setLastEventID(id string) {
-	es.lastEventIDMux.Lock()
-	defer es.lastEventIDMux.Unlock()
-	es.lastEventID = id
 }
 
 // Returns the channel of events. Events will be queued in the channel as they

--- a/eventsource.go
+++ b/eventsource.go
@@ -51,9 +51,9 @@ type (
 // NewEventSource constructs returns an EventSource that satisfies the HTML5 EventSource specification.
 func NewEventSource(url string) (EventSource, error) {
 	es := eventSource{
-		d:            nil,
-		url:          url,
-		out:          make(chan *MessageEvent),
+		d:   nil,
+		url: url,
+		out: make(chan *MessageEvent),
 	}
 	return &es, es.connect()
 }

--- a/eventsource.go
+++ b/eventsource.go
@@ -32,14 +32,14 @@ type (
 	EventSource interface {
 		URL() (url string)
 		ReadyState() (state ReadyState)
-		Events() (events <-chan *Event)
+		MessageEvents() (events <-chan *MessageEvent)
 		Close()
 	}
 	eventSource struct {
 		url          string
 		d            Decoder
 		resp         *http.Response
-		out          chan *Event
+		out          chan *MessageEvent
 		closeOutOnce chan struct{}
 
 		// Status of the event stream.
@@ -53,7 +53,7 @@ func NewEventSource(url string) (EventSource, error) {
 	es := eventSource{
 		d:            nil,
 		url:          url,
-		out:          make(chan *Event),
+		out:          make(chan *MessageEvent),
 	}
 	return &es, es.connect()
 }
@@ -169,9 +169,9 @@ func (es *eventSource) setReadyState(newState ReadyState) {
 	es.readyState = newState
 }
 
-// Returns the channel of events. Events will be queued in the channel as they
+// Returns the channel of events. MessageEvents will be queued in the channel as they
 // are received.
-func (es *eventSource) Events() <-chan *Event {
+func (es *eventSource) MessageEvents() <-chan *MessageEvent {
 	return es.out
 }
 

--- a/eventsource_test.go
+++ b/eventsource_test.go
@@ -179,14 +179,14 @@ func TestEventSourceLastEventID(t *testing.T) {
 		go handler.Send(eventBytes)
 		ev, ok := <-es.Events()
 		if assert.True(t, ok) {
-			assert.Equal(t, expectedID, es.LastEventID())
+			assert.Equal(t, expectedID, ev.LastEventID)
 			assert.Equal(t, expectedData, ev.Data)
 		}
 
 		go handler.Send(tests.NewEventWithPadding(32))
-		_, ok = <-es.Events()
+		ev, ok = <-es.Events()
 		if assert.True(t, ok) {
-			assert.Equal(t, expectedID, es.LastEventID())
+			assert.Equal(t, expectedID, ev.LastEventID)
 		}
 	}
 	assertCloseClient(t, es)

--- a/message_event.go
+++ b/message_event.go
@@ -1,6 +1,6 @@
 package sse
 
-type Event struct {
+type MessageEvent struct {
 	LastEventID string
 	Name        string
 	Data        string


### PR DESCRIPTION
In light of #30:

Fixed spec violations:
- Rename Event to MessageEvent to follow the spec naming convention.
- Decoder keeps track of lastEventID.
- Decoder keeps track of retry reconnection time value.
- Decoder sets MessageEvent LastEventID to the last known value before dispatching the event.

Minor things:
- EventSource does not attempt to reconnect if the first connection ever fails to establish.
- Decoder now does `data.String()` instead of `string(data.Bytes()`.

Relating to #34:
- Reconnection tests were weak:
  - AssertCannoReconnect: To assert that channel closes when reconnection cannot happen, no need to send event. Sending event without the delay also may race against handler.Close(). Remove it.
  - AssertCanReconnect: Sleep 25 milliseconds before sending an event, to ensure that handler.Close() is picked up.

Thanks to @dolmen for pointing this out. This will get rid of many spec violations regarding the interface of many things.

