### PR TITLE
eventsource: readyState should be unsigned char instead of byte.

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-type ReadyState byte
+type ReadyState uint16
 
 const (
 	AllowedContentType = "text/event-stream"


### PR DESCRIPTION
Fixes #32.