### PR TITLE
docs/readme: improve readme and add contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Contributions are welcome granted that:
+
+- HTML5 server-sent events specification is respected.
+- Existing tests do not break.
+- Source code is enhanced.
+- Code is formatted with `gofmt` (or `goimports`)
+
+For bug fixes (excluding bugs in tests) also:
+
+- Include a test that reproduces the bug, and passes.
+
+# Performance improvements
+
+Performance improvements to the library should be complimented with a benchmark
+comparison. The benchmarks should run at least 10 times. Use a tool such as 
+benchstat to ensure the results are statistically relevant.
+
+```
+go test -run=none -bench=. -c=10 github.com/mubit/sse/benchmarks > old.txt
+go test -run=none -bench=. -c=10 github.com/mubit/sse/benchmarks > new.txt
+benchstat old.txt new.txt
+```
+
+Thanks for the contributions.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,26 @@
-# HTML5 Server-Sent Events client for Golang
+# Go client for HTML5 Server-Sent Events
 
 [![Build Status](https://travis-ci.org/mubit/sse.svg?branch=master)](https://travis-ci.org/mubit/sse)
 [![GoDoc](https://godoc.org/github.com/mubit/sse?status.svg)](https://godoc.org/github.com/mubit/sse)
+[![GoReport](https://goreportcard.com/badge/github.com/mubit/sse)](https://goreportcard.com/report/github.com/mubit/sse)
 
-This package provides a fast Decoder to consume ServerSentEvents (SSE) in
-compliance to the the [HTML5 standard](https://html.spec.whatwg.org/multipage/comms.html).
+The package provides fast primitives to manipulate Server-Sent Events (SSE) as
+standardized in the [HTML5 standard](https://html.spec.whatwg.org/multipage/comms.html).
 
-## Installing
+> **Note**
+> Types and interfaces exposed by the package are subjected to change until 
+the project stabilises and matures, which is expected to happen by 1.0.0 release.
 
-`go get github.com/mubit/sse`
+Install the package running `go get github.com/mubit/sse`
 
-### Running tests & benchmarks
-
-`cd $GOPATH/src/github.com/mubit/sse && go test ./...`
-
-`cd $GOPATH/src/github.com/mubit/sse/benchmarks && go test -bench=.`
+Check the [contributing guidelines](CONTRIBUTING.md) when submitting changes.
 
 # Considerations
 
-- Not used in production, that I am aware.
+- Not aware of any use in production for this library.
 
-- Decoder performance could drop due memory copy when the SSE stream
-to be consumed provides line feeds using CRLF (`\r\n`), the library
-performs best when LF (`\n`) is used.
+- Priority is to be fully compliant with the specification. 
+A stable 1.0.0 release will promise that.
 
-- This package intends to be spec compliant, however: it might not be
-there yet. If you find a bug, do not hesitate to report it.
+- Feel free to report any bug or spec misalignment.
+


### PR DESCRIPTION
- README.md now states the inherent unstability of the package APIs
until we commit to the 1.0.0 release.

- CONTRIBUTING.md states the guidelines that should be followed to
contribute changes to the codebase.

Relates to #22 and closes #36.