### PR TITLE
ensure no events are sent to closed channels.

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -115,7 +115,9 @@ func (es *EventSource) consume() {
 			return
 		}
 		es.lastEventID = ev.LastEventID
-		es.out <- ev
+		if es.ReadyState() == Open {
+			es.out <- ev
+		}
 	}
 }
 


### PR DESCRIPTION
I was getting panics in a channel loop like this:

```
for ev := range es.MessageEvents() {
  doSomething(ev.Data)
  es.Close()
  break
}
```