### PR TITLE
decoder: conform last event id decoding to the spec

### DIFF
--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -70,7 +70,11 @@ func (d *Decoder) Decode() (*base.MessageEvent, error) {
 				// the name of any event as defined in the DOM Events spec.
 				// Decoder does not perform this check, hence it could yield
 				// events that would not be valid in a browser.
-				return &base.MessageEvent{LastEventID: d.lastEventID, Name: name, Data: d.data.String()}, nil
+				return &base.MessageEvent{
+					Name:        name,
+					Data:        d.data.String(),
+					LastEventID: d.lastEventID,
+				}, nil
 			}
 
 			continue
@@ -105,8 +109,10 @@ func (d *Decoder) Decode() (*base.MessageEvent, error) {
 			d.data.WriteByte('\n')
 			eventSeen = true
 		case "id":
-			d.lastEventID = value
-			eventSeen = true
+			if !strings.Contains(value, "\u0000") {
+				d.lastEventID = value
+				eventSeen = true
+			}
 		case "retry":
 			retry, err := strconv.Atoi(value)
 			if err == nil && retry >= 0 {

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -101,6 +102,26 @@ func TestEventsWithNoDataThenWithNewLine(t *testing.T) {
 	ev2, err := decoder.Decode()
 	if assert.NoError(t, err) {
 		assert.Equal(t, "\n", ev2.Data)
+	}
+}
+
+func TestDecode_LastEventId_returnsId(t *testing.T) {
+	stream := fmt.Sprintf("data: test\nid: valid id\n\n")
+	decoder := newDecoder(stream)
+
+	ev, err := decoder.Decode()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "valid id", ev.LastEventID)
+	}
+}
+
+func TestDecode_LastEventId_ignoresNullCharater(t *testing.T) {
+	stream := fmt.Sprintf("data: test\nid: invalid id \u0000\n\n")
+	decoder := newDecoder(stream)
+
+	ev, err := decoder.Decode()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "", ev.LastEventID)
 	}
 }
 


### PR DESCRIPTION
If the value contains NULL value, then it is ignored.

See https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation

> If the field name is "id":
> If the field value does not contain U+0000 NULL, then set the last event ID buffer to the field value. Otherwise, ignore the field.