### PR TITLE
eventsource: fix all data races, and ensure es.out is closed once

### DIFF
--- a/pkg/eventsource/eventsource_test.go
+++ b/pkg/eventsource/eventsource_test.go
@@ -12,9 +12,10 @@ import (
 func TestEventSource_WhenConnect_ThenNoError(t *testing.T) {
 	setUp(t, func(handler *server.MockHandler) {
 		sut, err := New(handler.URL)
-		defer sut.Close()
 
 		assert.NoError(t, err)
+
+		sut.Close()
 	})
 }
 
@@ -52,10 +53,11 @@ func TestEventSource_WhenInvalidContentType_ThenReturnsError(t *testing.T) {
 	setUp(t, func(handler *server.MockHandler) {
 		handler.ContentType = "text/plain; charset=utf-8"
 		sut, err := New(handler.URL)
-		defer sut.Close()
 
 		assert.Equal(t, ErrContentType, err)
 		assertStates(t, []ReadyState{Connecting, Closed}, sut)
+
+		sut.Close()
 	})
 }
 
@@ -207,9 +209,9 @@ func TestEventSource_WithBasicAuth_InvalidPassword(t *testing.T) {
 		handler.BasicAuth.Password = "bar"
 
 		sut, err := New(handler.URL, WithBasicAuth("foo", ""))
-		defer sut.Close()
-
 		assert.Equal(t, ErrUnauthorized, err)
+
+		sut.Close()
 	})
 }
 
@@ -259,7 +261,6 @@ func collectStates(states <-chan Status) []ReadyState {
 		select {
 		case status := <-states:
 			list = append(list, status.ReadyState)
-			break
 		case <-time.After(10 * time.Millisecond):
 			return list
 		}


### PR DESCRIPTION
Re-writes how the `eventsource.go` consumer goroutine works in order to address outstanding issues (eg. the one mentioned in https://github.com/alevinval/sse/issues/56)

- The `consume` goroutine is spawned only once
  - The closing of the `es.out` channel happens only once, when the goroutine exits
  - The initial connection and the potential reconnections all happen within the goroutine
- Synchronisation is added to safely access the `http.Response` instance
  - This is necessary to manually close the event source, since the `Decoder` blocks as long as the connection is open. By closing the body, we ensure the goroutine can resume execution and exit cleanly

In general, all data races have been addressed.
