### PR TITLE
ci: deterministic tests

### DIFF
--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -2,6 +2,8 @@ package testutils
 
 import (
 	"math/rand"
+	"testing"
+	"time"
 
 	"github.com/alevinval/sse/pkg/base"
 )
@@ -18,4 +20,17 @@ func randString(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+func ExpectCondition(t *testing.T, condition func() bool) {
+	n, max, sleep := 0, 10, 25
+	for n < max {
+		n++
+		if condition() {
+			return
+		}
+		time.Sleep(time.Duration(sleep) * time.Millisecond)
+	}
+
+	t.Errorf("expected condition never happened after %d polls", n)
 }

--- a/internal/testutils/server/handler.go
+++ b/internal/testutils/server/handler.go
@@ -16,8 +16,6 @@ const contentTypeEventStream = "text/event-stream; charset=utf-8"
 // MockHandler used to emulate an http server that follows
 // the SSE spec
 type MockHandler struct {
-	// Server instance of the test HTTP server
-	Server *httptest.Server
 
 	// URL of the HTTP test server
 	URL string
@@ -39,6 +37,7 @@ type MockHandler struct {
 	Connected chan struct{}
 
 	t           *testing.T
+	server      *httptest.Server
 	encoder     *encoder.Encoder
 	flusher     http.Flusher
 	lastEventID string
@@ -54,8 +53,8 @@ func NewMockHandler(t *testing.T) *MockHandler {
 		closer:               make(chan struct{}),
 		Connected:            make(chan struct{}, 1),
 	}
-	handler.Server = httptest.NewServer(handler)
-	handler.URL = handler.Server.URL
+	handler.server = httptest.NewServer(handler)
+	handler.URL = handler.server.URL
 	return handler
 }
 
@@ -134,5 +133,5 @@ func (h *MockHandler) CloseActiveRequest(block bool) {
 // test HTTP server
 func (h *MockHandler) Close() {
 	h.CloseActiveRequest(false)
-	h.Server.Close()
+	h.server.Close()
 }

--- a/internal/testutils/server/handler.go
+++ b/internal/testutils/server/handler.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,8 +16,6 @@ const contentTypeEventStream = "text/event-stream; charset=utf-8"
 // MockHandler used to emulate an http server that follows
 // the SSE spec
 type MockHandler struct {
-	sync.Mutex
-
 	// Server instance of the test HTTP server
 	Server *httptest.Server
 
@@ -122,9 +119,6 @@ func (h *MockHandler) WriteRetry(delayInMillis int) {
 }
 
 func (h *MockHandler) Flush() {
-	h.Lock()
-	defer h.Unlock()
-
 	if h.flusher != nil {
 		h.flusher.Flush()
 	}
@@ -151,8 +145,5 @@ func (h *MockHandler) Close() {
 }
 
 func (h *MockHandler) setFlusher(flusher http.Flusher) {
-	h.Lock()
-	defer h.Unlock()
-
 	h.flusher = flusher
 }

--- a/pkg/eventsource/eventsource_test.go
+++ b/pkg/eventsource/eventsource_test.go
@@ -90,7 +90,7 @@ func TestEventSource_WhenMultipleWrites_ThenKeepsLastEventID(t *testing.T) {
 		defer sut.Close()
 
 		<-handler.Connected
-		handler.WriteRetry(1)
+		handler.WriteRetry(1, sut.getDecoder)
 		handler.WriteEvent(eventWithID)
 		assertReceive(t, sut, eventWithID)
 		assert.Equal(t, "event-id", sut.lastEventID)
@@ -138,11 +138,11 @@ func TestEventSource_WhenReconnecting_RetryIsRespected(t *testing.T) {
 		defer sut.Close()
 
 		<-handler.Connected
-		handler.WriteRetry(int(longDelay.Milliseconds()))
+		handler.WriteRetry(int(longDelay.Milliseconds()), sut.getDecoder)
 		handler.CloseActiveRequest(true)
 		assertConnectionWithinDeadline(t, handler, longDelay, 2*longDelay)
 
-		handler.WriteRetry(int(shortDelay.Milliseconds()))
+		handler.WriteRetry(int(shortDelay.Milliseconds()), sut.getDecoder)
 		handler.CloseActiveRequest(true)
 		assertConnectionWithinDeadline(t, handler, shortDelay, longDelay)
 
@@ -160,7 +160,7 @@ func TestEventSource_WhenConnectionDropped_CannotReconnect(t *testing.T) {
 		defer sut.Close()
 
 		<-handler.Connected
-		handler.WriteRetry(1)
+		handler.WriteRetry(1, sut.getDecoder)
 		handler.CloseActiveRequest(true)
 
 		assertNoReceives(t, sut)
@@ -179,7 +179,7 @@ func TestEventSource_DropConnection_CanReconnect(t *testing.T) {
 		defer sut.Close()
 
 		<-handler.Connected
-		handler.WriteRetry(1)
+		handler.WriteRetry(1, sut.getDecoder)
 		handler.CloseActiveRequest(true)
 		<-handler.Connected
 


### PR DESCRIPTION
It was relatively easy to trigger non-deterministic test runs, mostly on the suite that validates the reconnection mechanism, and the tests that ensure retry time is respected. Now, when writing a retry value, it polls the underlying decoder until the retry has been decoded. Since those changes, I've not been able to reproduce the race once (although it's technically still possible)